### PR TITLE
Fix API calls to use backend port

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 MSSQL_CONNECTION_STRING="server=localhost;uid=sa;pwd=reallyStrongPwd123;database=todo_manager;TrustServerCertificate=true;"
 JWT_SECRET="changeme"
+NEXT_PUBLIC_API_URL="http://localhost:3001"

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 MSSQL_CONNECTION_STRING="server=localhost;uid=sa;pwd=reallyStrongPwd123;database=todo_manager;TrustServerCertificate=true;"
 JWT_SECRET="changeme"
+NEXT_PUBLIC_API_URL="http://localhost:3001"

--- a/context/tasks-provider.tsx
+++ b/context/tasks-provider.tsx
@@ -3,6 +3,8 @@
 import type React from "react"
 import { createContext, useContext, useReducer, useEffect, type ReactNode } from "react"
 
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || ""
+
 // Types for our task management system
 export interface Task {
   id: string
@@ -245,7 +247,7 @@ export function TasksProvider({ children }: { children: ReactNode }) {
         console.error("Failed to parse saved tasks:", error)
       }
     } else {
-      fetch("/api/tasks")
+      fetch(`${API_BASE}/api/tasks`)
         .then((res) => res.json())
         .then((data) => {
           dispatch({ type: "SET_TASKS", payload: data })

--- a/hooks/use-tasks.ts
+++ b/hooks/use-tasks.ts
@@ -3,6 +3,8 @@
 import { useTasks, type Task } from "@/context/tasks-provider"
 import { useCallback } from "react"
 
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || ""
+
 // Custom hook for task operations with API integration
 export function useTaskOperations() {
   const { state, dispatch } = useTasks()
@@ -18,7 +20,7 @@ export function useTaskOperations() {
       }
 
       try {
-        const res = await fetch("/api/tasks", {
+        const res = await fetch(`${API_BASE}/api/tasks`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(taskData),
@@ -49,7 +51,7 @@ export function useTaskOperations() {
       }
 
       try {
-        await fetch(`/api/tasks/${updatedTask.id}`, {
+        await fetch(`${API_BASE}/api/tasks/${updatedTask.id}`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(taskWithUpdatedTime),
@@ -77,7 +79,7 @@ export function useTaskOperations() {
       if (!taskToDelete) return
 
       try {
-        await fetch(`/api/tasks/${taskId}`, { method: "DELETE" })
+        await fetch(`${API_BASE}/api/tasks/${taskId}`, { method: "DELETE" })
 
         dispatch({ type: "DELETE_TASK", payload: taskId })
         dispatch({
@@ -105,7 +107,7 @@ export function useTaskOperations() {
   const toggleTask = useCallback(
     async (taskId: string) => {
       try {
-        await fetch(`/api/tasks/${taskId}/toggle`, { method: "PATCH" })
+        await fetch(`${API_BASE}/api/tasks/${taskId}/toggle`, { method: "PATCH" })
 
         dispatch({ type: "TOGGLE_TASK", payload: taskId })
       } catch (error) {


### PR DESCRIPTION
## Summary
- fetch the API base URL from `NEXT_PUBLIC_API_URL`
- update sample environment files with `NEXT_PUBLIC_API_URL`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af3af7078832182fbc676455535f2