### PR TITLE
Fix task creation and delete confirmation

### DIFF
--- a/components/task-card.tsx
+++ b/components/task-card.tsx
@@ -3,6 +3,17 @@
 import type React from "react"
 
 import { Edit, Trash2 } from "lucide-react"
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "@/components/ui/alert-dialog"
 import { useTasks } from "@/context/tasks-provider"
 import { useTaskOperations } from "@/hooks/use-tasks"
 import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities"
@@ -137,13 +148,29 @@ export function TaskCard({
         >
           <Edit className="h-4 w-4" />
         </button>
-        <button
-          onClick={handleDelete}
-          className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 rounded-lg"
-          aria-label={`Görevi sil "${title}"`}
-        >
-          <Trash2 className="h-4 w-4" />
-        </button>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <button
+              onClick={(e) => e.stopPropagation()}
+              className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 rounded-lg"
+              aria-label={`Görevi sil "${title}"`}
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Görev silinsin mi?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Bu işlem geri alınamaz. Silmek istediğinize emin misiniz?
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Vazgeç</AlertDialogCancel>
+              <AlertDialogAction onClick={handleDelete}>Sil</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </div>
 
       {/* Task content with better spacing and layout */}

--- a/components/task-detail-modal.tsx
+++ b/components/task-detail-modal.tsx
@@ -1,6 +1,17 @@
 "use client"
 
 import { X, Edit, Trash2, Calendar, Flag } from "lucide-react"
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "@/components/ui/alert-dialog"
 import { useTasks } from "@/context/tasks-provider"
 import { useTaskOperations } from "@/hooks/use-tasks"
 
@@ -56,8 +67,10 @@ export function TaskDetailModal() {
     }
   }
 
-  const formatDate = (dateString: string) => {
+  const formatDate = (dateString?: string) => {
+    if (!dateString) return "-"
     const date = new Date(dateString)
+    if (isNaN(date.getTime())) return "-"
     return date.toLocaleDateString("tr-TR", {
       year: "numeric",
       month: "long",
@@ -157,13 +170,29 @@ export function TaskDetailModal() {
               <Edit className="h-4 w-4 inline mr-2" />
               Düzenle
             </button>
-            <button
-              onClick={handleDelete}
-              className="px-4 py-2 bg-red-100 text-red-800 hover:bg-red-200 rounded-lg font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
-            >
-              <Trash2 className="h-4 w-4 inline mr-2" />
-              Sil
-            </button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <button
+                  onClick={(e) => e.stopPropagation()}
+                  className="px-4 py-2 bg-red-100 text-red-800 hover:bg-red-200 rounded-lg font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+                >
+                  <Trash2 className="h-4 w-4 inline mr-2" />
+                  Sil
+                </button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Görev silinsin mi?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Bu işlem geri alınamaz. Silmek istediğinize emin misiniz?
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Vazgeç</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleDelete}>Sil</AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- handle missing metadata in task interface
- improve API error handling with auth headers
- use Radix alert dialog for confirming deletions
- gracefully format undefined dates

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af83277b48321a880043ef6546741