### PR TITLE
Fix dynamic auth header retrieval

### DIFF
--- a/context/tasks-provider.tsx
+++ b/context/tasks-provider.tsx
@@ -235,8 +235,10 @@ const TasksContext = createContext<{
 // Provider component
 export function TasksProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(tasksReducer, initialState)
-  const token = typeof window !== "undefined" ? localStorage.getItem("token") : null
-  const authHeader = token ? { Authorization: `Bearer ${token}` } : {}
+  const getAuthHeader = () => {
+    const token = typeof window !== "undefined" ? localStorage.getItem("token") : null
+    return token ? { Authorization: `Bearer ${token}` } : {}
+  }
 
   // Load tasks on mount
   useEffect(() => {
@@ -249,7 +251,7 @@ export function TasksProvider({ children }: { children: ReactNode }) {
         console.error("Failed to parse saved tasks:", error)
       }
     } else {
-      fetch(`${API_BASE}/api/tasks`, { headers: { ...authHeader } })
+        fetch(`${API_BASE}/api/tasks`, { headers: { ...getAuthHeader() } })
         .then(async (res) => {
           if (!res.ok) {
             const err = await res.json()

--- a/hooks/use-tasks.ts
+++ b/hooks/use-tasks.ts
@@ -8,10 +8,11 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL || ""
 // Custom hook for task operations with API integration
 export function useTaskOperations() {
   const { state, dispatch } = useTasks()
-  const token =
-    typeof window !== "undefined" ? localStorage.getItem("token") : null
-
-  const authHeader = token ? { Authorization: `Bearer ${token}` } : {}
+  const getAuthHeader = () => {
+    const token =
+      typeof window !== "undefined" ? localStorage.getItem("token") : null
+    return token ? { Authorization: `Bearer ${token}` } : {}
+  }
 
   // Add a new task
   const addTask = useCallback(
@@ -26,7 +27,7 @@ export function useTaskOperations() {
       try {
         const res = await fetch(`${API_BASE}/api/tasks`, {
           method: "POST",
-          headers: { "Content-Type": "application/json", ...authHeader },
+          headers: { "Content-Type": "application/json", ...getAuthHeader() },
           body: JSON.stringify(taskData),
         })
         if (!res.ok) {
@@ -61,7 +62,7 @@ export function useTaskOperations() {
       try {
         const res = await fetch(`${API_BASE}/api/tasks/${updatedTask.id}`, {
           method: "PUT",
-          headers: { "Content-Type": "application/json", ...authHeader },
+          headers: { "Content-Type": "application/json", ...getAuthHeader() },
           body: JSON.stringify(taskWithUpdatedTime),
         })
         if (!res.ok) {
@@ -93,7 +94,7 @@ export function useTaskOperations() {
       try {
         const res = await fetch(`${API_BASE}/api/tasks/${taskId}`, {
           method: "DELETE",
-          headers: { ...authHeader },
+          headers: { ...getAuthHeader() },
         })
         if (!res.ok) {
           const err = await res.json()
@@ -128,7 +129,7 @@ export function useTaskOperations() {
       try {
         const res = await fetch(`${API_BASE}/api/tasks/${taskId}/toggle`, {
           method: "PATCH",
-          headers: { ...authHeader },
+          headers: { ...getAuthHeader() },
         })
         if (!res.ok) {
           const err = await res.json()


### PR DESCRIPTION
## Summary
- retrieve token from localStorage each time a task API call is made
- do the same for initial task load in provider

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686afa54c0ac832188f177de819a933b