### PR TITLE
Fix task creation with completed field

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This repository also includes an Express.js API powering the React frontend.
 ### Endpoints
 
 - `GET /api/tasks` – List your tasks. Query params: `filter=all|active|completed`, `search`.
-- `POST /api/tasks` – Create a task with `{title, description?, priority?}`.
+- `POST /api/tasks` – Create a task with `{title, description?, priority?, completed?}`.
 - `PUT /api/tasks/:id` – Update any task field.
 - `PATCH /api/tasks/:id/toggle` – Toggle completion.
 - `DELETE /api/tasks/:id` – Delete a task.

--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -6,6 +6,7 @@ const createSchema = Joi.object({
   title: Joi.string().required(),
   description: Joi.string().allow(''),
   priority: Joi.string().valid('Low', 'Medium', 'High'),
+  completed: Joi.boolean(),
 });
 
 const updateSchema = Joi.object({
@@ -47,8 +48,9 @@ exports.create = async (req, res, next) => {
       .input('title', sql.NVarChar, value.title)
       .input('description', sql.NVarChar, value.description || null)
       .input('priority', sql.NVarChar, value.priority || 'Low')
+      .input('completed', sql.Bit, value.completed ?? false)
       .query(
-        'INSERT INTO Tasks (title, description, priority) OUTPUT INSERTED.* VALUES (@title, @description, @priority)'
+        'INSERT INTO Tasks (title, description, priority, completed) OUTPUT INSERTED.* VALUES (@title, @description, @priority, @completed)'
       )
     res.status(201).json(result.recordset[0])
   } catch (err) {


### PR DESCRIPTION
## Summary
- allow `completed` in validation for creating tasks
- insert `completed` in the Tasks table when creating
- document the optional `completed` field in the API README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686afd64b6648321a3de1193766373fe