### PR TITLE
Fix update task API call

### DIFF
--- a/hooks/use-tasks.ts
+++ b/hooks/use-tasks.ts
@@ -54,11 +54,19 @@ export function useTaskOperations() {
         updatedAt: new Date().toISOString(),
       }
 
+      // Only send fields that API expects
+      const payload = {
+        title: taskWithUpdatedTime.title,
+        description: taskWithUpdatedTime.description,
+        priority: taskWithUpdatedTime.priority,
+        completed: taskWithUpdatedTime.completed,
+      }
+
       try {
         const res = await fetch(`${API_BASE}/api/tasks/${updatedTask.id}`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(taskWithUpdatedTime),
+          body: JSON.stringify(payload),
         })
         if (!res.ok) {
           const err = await res.json()


### PR DESCRIPTION
## Summary
- only send the fields expected by the API when updating a task

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686affaf4c9883218d09b30a8b7a5c08