### PR TITLE
Fix Next.js build failure

### DIFF
--- a/components/onboarding-tour.tsx
+++ b/components/onboarding-tour.tsx
@@ -1,6 +1,6 @@
 "use client"
 import React from 'react'
-import Joyride from 'react-joyride'
+
 
 const steps = [
   {
@@ -18,23 +18,15 @@ const steps = [
 ]
 
 export function OnboardingTour() {
-  const [run, setRun] = React.useState(false)
   React.useEffect(() => {
     if (!localStorage.getItem('tourDone')) {
-      setRun(true)
+      // Basit bir tur için her adımın içeriğini alert ile göster
+      for (const step of steps) {
+        window.alert(step.content)
+      }
+      localStorage.setItem('tourDone', 'true')
     }
   }, [])
-  return (
-    <Joyride
-      steps={steps}
-      run={run}
-      continuous
-      showSkipButton
-      callback={(data) => {
-        if (data.status === 'finished' || data.status === 'skipped') {
-          localStorage.setItem('tourDone', 'true')
-        }
-      }}
-    />
-  )
+
+  return null
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,6 @@
         "react-day-picker": "8.10.1",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.54.1",
-        "react-joyride": "^2.9.3",
         "react-loading-skeleton": "^3.3.1",
         "react-resizable-panels": "^2.1.7",
         "recharts": "2.15.0",
@@ -8666,35 +8665,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
-    },
-    "node_modules/react-joyride": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-2.9.3.tgz",
-      "integrity": "sha512-1+Mg34XK5zaqJ63eeBhqdbk7dlGCFp36FXwsEvgpjqrtyywX2C6h9vr3jgxP0bGHCw8Ilsp/nRDzNVq6HJ3rNw==",
-      "license": "MIT",
-      "dependencies": {
-        "@gilbarbara/deep-equal": "^0.3.1",
-        "deep-diff": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "is-lite": "^1.2.1",
-        "react-floater": "^0.7.9",
-        "react-innertext": "^1.1.5",
-        "react-is": "^16.13.1",
-        "scroll": "^3.0.1",
-        "scrollparent": "^2.1.0",
-        "tree-changes": "^0.11.2",
-        "type-fest": "^4.27.0"
-      },
-      "peerDependencies": {
-        "react": "15 - 18",
-        "react-dom": "15 - 18"
-      }
-    },
-    "node_modules/react-joyride/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "react-day-picker": "8.10.1",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.54.1",
-    "react-joyride": "^2.9.3",
     "react-loading-skeleton": "^3.3.1",
     "react-resizable-panels": "^2.1.7",
     "recharts": "2.15.0",


### PR DESCRIPTION
## Summary
- remove `react-joyride` as it's incompatible with Next 15
- replace tour logic with a simple alert-based tour

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b12d560e88321a0a3332af98768bf