### PR TITLE
Add authentication workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ This repository also includes an Express.js API powering the React frontend.
    ```bash
    npm start
    ```
+4. The frontend expects the API to run on `http://localhost:3001`. If you change
+   the backend URL, set `NEXT_PUBLIC_API_URL` accordingly in `.env`.
 
 ### Endpoints
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import { ThemeProvider } from '@/components/theme-provider'
+import { AuthProvider } from '@/context/auth-provider'
 import './globals.css'
 
 const inter = Inter({ subsets: ['latin'] })
@@ -19,9 +20,11 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
-        <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
-          {children}
-        </ThemeProvider>
+        <AuthProvider>
+          <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+            {children}
+          </ThemeProvider>
+        </AuthProvider>
       </body>
     </html>
   )

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import Link from "next/link"
+import { useAuth } from "@/context/auth-provider"
+
+export default function LoginPage() {
+  const { login } = useAuth()
+  const router = useRouter()
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [error, setError] = useState("")
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      await login(email, password)
+      router.push("/")
+    } catch (err: any) {
+      setError(err.message)
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gradient-to-r from-sky-50 via-white to-emerald-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 p-4">
+      <form onSubmit={handleSubmit} className="bg-white dark:bg-gray-900 p-8 rounded-lg shadow w-full max-w-md space-y-4">
+        <h1 className="text-2xl font-semibold text-center">Giriş Yap</h1>
+        <div>
+          <label htmlFor="email" className="block text-sm mb-1">Email</label>
+          <input id="email" type="email" value={email} onChange={e=>setEmail(e.target.value)} required className="w-full px-3 py-2 border rounded-md" />
+        </div>
+        <div>
+          <label htmlFor="password" className="block text-sm mb-1">Şifre</label>
+          <input id="password" type="password" value={password} onChange={e=>setPassword(e.target.value)} required className="w-full px-3 py-2 border rounded-md" />
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <button type="submit" className="w-full px-4 py-2 bg-blue-600 text-white rounded-md">Giriş Yap</button>
+        <p className="text-sm text-center">Hesabınız yok mu? <Link href="/register" className="text-blue-600 hover:underline">Kayıt Ol</Link></p>
+      </form>
+    </div>
+  )
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { useAuth } from "@/context/auth-provider"
+
+export default function ProfilePage() {
+  const { user, updateProfile, logout, loading } = useAuth()
+  const router = useRouter()
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [message, setMessage] = useState("")
+
+  useEffect(() => {
+    if (user) setEmail(user.email)
+  }, [user])
+
+  if (!loading && !user) {
+    router.push("/login")
+    return null
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      await updateProfile({ email, password: password || undefined })
+      setPassword("")
+      setMessage("Bilgiler güncellendi")
+    } catch (err: any) {
+      setMessage(err.message)
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gradient-to-r from-sky-50 via-white to-emerald-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 p-4">
+      <form onSubmit={handleSubmit} className="bg-white dark:bg-gray-900 p-8 rounded-lg shadow w-full max-w-md space-y-4">
+        <h1 className="text-2xl font-semibold text-center">Profil</h1>
+        <div>
+          <label htmlFor="email" className="block text-sm mb-1">Email</label>
+          <input id="email" type="email" value={email} onChange={e=>setEmail(e.target.value)} required className="w-full px-3 py-2 border rounded-md" />
+        </div>
+        <div>
+          <label htmlFor="password" className="block text-sm mb-1">Yeni Şifre</label>
+          <input id="password" type="password" value={password} onChange={e=>setPassword(e.target.value)} className="w-full px-3 py-2 border rounded-md" />
+        </div>
+        {message && <p className="text-sm text-center text-green-600">{message}</p>}
+        <button type="submit" className="w-full px-4 py-2 bg-blue-600 text-white rounded-md">Güncelle</button>
+        <button type="button" onClick={()=>{logout();router.push('/')}} className="w-full px-4 py-2 bg-gray-500 text-white rounded-md">Çıkış Yap</button>
+      </form>
+    </div>
+  )
+}

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import Link from "next/link"
+import { useAuth } from "@/context/auth-provider"
+
+export default function RegisterPage() {
+  const { register } = useAuth()
+  const router = useRouter()
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [error, setError] = useState("")
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      await register(email, password)
+      router.push("/")
+    } catch (err: any) {
+      setError(err.message)
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gradient-to-r from-sky-50 via-white to-emerald-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 p-4">
+      <form onSubmit={handleSubmit} className="bg-white dark:bg-gray-900 p-8 rounded-lg shadow w-full max-w-md space-y-4">
+        <h1 className="text-2xl font-semibold text-center">Kayıt Ol</h1>
+        <div>
+          <label htmlFor="email" className="block text-sm mb-1">Email</label>
+          <input id="email" type="email" value={email} onChange={e=>setEmail(e.target.value)} required className="w-full px-3 py-2 border rounded-md" />
+        </div>
+        <div>
+          <label htmlFor="password" className="block text-sm mb-1">Şifre</label>
+          <input id="password" type="password" value={password} onChange={e=>setPassword(e.target.value)} required className="w-full px-3 py-2 border rounded-md" />
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <button type="submit" className="w-full px-4 py-2 bg-blue-600 text-white rounded-md">Kayıt Ol</button>
+        <p className="text-sm text-center">Zaten hesabınız var mı? <Link href="/login" className="text-blue-600 hover:underline">Giriş Yap</Link></p>
+      </form>
+    </div>
+  )
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,14 +1,17 @@
 "use client"
 
-import { Search } from "lucide-react"
+import { Search, UserCircle2 } from "lucide-react"
 import { useTasks } from "@/context/tasks-provider"
 import { useEffect, useState } from "react"
 import { DarkModeToggle } from "@/components/dark-mode-toggle"
 import { ThemeEditor } from "@/components/theme-editor"
+import Link from "next/link"
+import { useAuth } from "@/context/auth-provider"
 
 export function Header() {
   const { state, dispatch } = useTasks()
   const [searchInput, setSearchInput] = useState("")
+  const { user } = useAuth()
 
   // Debounced search implementation
   useEffect(() => {
@@ -27,6 +30,9 @@ export function Header() {
         <div className="flex items-center space-x-2">
           <ThemeEditor />
           <DarkModeToggle />
+          <Link href={user ? "/profile" : "/login"} aria-label="Hesap" className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white">
+            <UserCircle2 className="w-6 h-6" />
+          </Link>
         </div>
       </div>
 

--- a/context/auth-provider.tsx
+++ b/context/auth-provider.tsx
@@ -2,7 +2,8 @@
 
 import { createContext, useContext, useEffect, useState, ReactNode } from "react"
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || ""
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001"
 
 interface User {
   id: number

--- a/context/auth-provider.tsx
+++ b/context/auth-provider.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import { createContext, useContext, useEffect, useState, ReactNode } from "react"
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || ""
+
+interface User {
+  id: number
+  email: string
+}
+
+interface AuthContextValue {
+  user: User | null
+  token: string | null
+  loading: boolean
+  login: (email: string, password: string) => Promise<void>
+  register: (email: string, password: string) => Promise<void>
+  logout: () => void
+  updateProfile: (data: { email?: string; password?: string }) => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [token, setToken] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const stored = localStorage.getItem("token")
+    if (stored) {
+      setToken(stored)
+      fetch(`${API_BASE}/api/auth/me`, {
+        headers: { Authorization: `Bearer ${stored}` },
+      })
+        .then((r) => (r.ok ? r.json() : Promise.reject()))
+        .then((data) => {
+          setUser(data)
+          setLoading(false)
+        })
+        .catch(() => {
+          localStorage.removeItem("token")
+          setToken(null)
+          setLoading(false)
+        })
+    } else {
+      setLoading(false)
+    }
+  }, [])
+
+  const login = async (email: string, password: string) => {
+    const res = await fetch(`${API_BASE}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    })
+    if (!res.ok) {
+      const err = await res.json()
+      throw new Error(err.error || "Giriş yapılamadı")
+    }
+    const data = await res.json()
+    localStorage.setItem("token", data.token)
+    setToken(data.token)
+    const profile = await fetch(`${API_BASE}/api/auth/me`, {
+      headers: { Authorization: `Bearer ${data.token}` },
+    }).then((r) => r.json())
+    setUser(profile)
+  }
+
+  const register = async (email: string, password: string) => {
+    const res = await fetch(`${API_BASE}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    })
+    if (!res.ok) {
+      const err = await res.json()
+      throw new Error(err.error || "Kayıt başarısız")
+    }
+    const data = await res.json()
+    localStorage.setItem("token", data.token)
+    setToken(data.token)
+    setUser(await fetch(`${API_BASE}/api/auth/me`, { headers: { Authorization: `Bearer ${data.token}` } }).then((r) => r.json()))
+  }
+
+  const logout = () => {
+    setUser(null)
+    setToken(null)
+    localStorage.removeItem("token")
+  }
+
+  const updateProfile = async (d: { email?: string; password?: string }) => {
+    if (!token) return
+    const res = await fetch(`${API_BASE}/api/auth/me`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(d),
+    })
+    if (!res.ok) {
+      const err = await res.json()
+      throw new Error(err.error || "Güncelleme başarısız")
+    }
+    const data = await res.json()
+    setUser(data)
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, token, loading, login, register, logout, updateProfile }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider")
+  return ctx
+}

--- a/context/tasks-provider.tsx
+++ b/context/tasks-provider.tsx
@@ -4,7 +4,8 @@ import type React from "react"
 import { createContext, useContext, useReducer, useEffect, type ReactNode } from "react"
 import { useAuth } from "@/context/auth-provider"
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || ""
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001"
 
 // Types for our task management system
 export interface Task {

--- a/hooks/use-tasks.ts
+++ b/hooks/use-tasks.ts
@@ -4,7 +4,8 @@ import { useTasks, type Task } from "@/context/tasks-provider"
 import { useCallback } from "react"
 import { useAuth } from "@/context/auth-provider"
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || ""
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001"
 
 // Custom hook for task operations with API integration
 export function useTaskOperations() {

--- a/hooks/use-tasks.ts
+++ b/hooks/use-tasks.ts
@@ -2,12 +2,14 @@
 
 import { useTasks, type Task } from "@/context/tasks-provider"
 import { useCallback } from "react"
+import { useAuth } from "@/context/auth-provider"
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || ""
 
 // Custom hook for task operations with API integration
 export function useTaskOperations() {
   const { state, dispatch } = useTasks()
+  const { token } = useAuth()
 
   // Add a new task
   const addTask = useCallback(
@@ -23,7 +25,7 @@ export function useTaskOperations() {
       try {
         const res = await fetch(`${API_BASE}/api/tasks`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
           body: JSON.stringify(taskData),
         })
         if (!res.ok) {
@@ -66,7 +68,7 @@ export function useTaskOperations() {
       try {
         const res = await fetch(`${API_BASE}/api/tasks/${updatedTask.id}`, {
           method: "PUT",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
           body: JSON.stringify(payload),
         })
         if (!res.ok) {
@@ -98,6 +100,7 @@ export function useTaskOperations() {
       try {
         const res = await fetch(`${API_BASE}/api/tasks/${taskId}`, {
           method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
         })
         if (!res.ok) {
           const err = await res.json()
@@ -132,6 +135,7 @@ export function useTaskOperations() {
       try {
         const res = await fetch(`${API_BASE}/api/tasks/${taskId}/toggle`, {
           method: "PATCH",
+          headers: { Authorization: `Bearer ${token}` },
         })
         if (!res.ok) {
           const err = await res.json()

--- a/src/config/db.js
+++ b/src/config/db.js
@@ -20,11 +20,20 @@ module.exports = async function connect(connectionString) {
       IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'Tasks') AND type in (N'U'))
       CREATE TABLE Tasks (
         id INT IDENTITY(1,1) PRIMARY KEY,
+        userId INT NOT NULL,
         title NVARCHAR(255) NOT NULL,
         description NVARCHAR(MAX),
         priority NVARCHAR(10) DEFAULT 'Low',
-        completed BIT DEFAULT 0
+        completed BIT DEFAULT 0,
+        FOREIGN KEY (userId) REFERENCES Users(id)
       )
+    `)
+    // Ensure userId column exists if table was created previously without it
+    await pool.request().query(`
+      IF COL_LENGTH('Tasks','userId') IS NULL
+      BEGIN
+        ALTER TABLE Tasks ADD userId INT NOT NULL DEFAULT 0;
+      END
     `)
   } catch (err) {
     console.error('MSSQL connection error:', err.message)

--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -16,18 +16,18 @@ const updateSchema = Joi.object({
   completed: Joi.boolean(),
 }).min(1);
 
-// List tasks with optional filter/search
+// List tasks for logged in user with optional filter/search
 exports.list = async (req, res, next) => {
   try {
     const { filter = 'all', search = '' } = req.query
     const pool = getPool()
-    let query = 'SELECT * FROM Tasks'
+    let query = 'SELECT * FROM Tasks WHERE userId=@userId'
     const conditions = []
     if (filter === 'active') conditions.push('completed = 0')
     if (filter === 'completed') conditions.push('completed = 1')
     if (search) conditions.push('(title LIKE @search OR description LIKE @search)')
-    if (conditions.length > 0) query += ' WHERE ' + conditions.join(' AND ')
-    const request = pool.request()
+    if (conditions.length > 0) query += ' AND ' + conditions.join(' AND ')
+    const request = pool.request().input('userId', sql.Int, req.userId)
     if (search) request.input('search', sql.NVarChar, `%${search}%`)
     const { recordset } = await request.query(query + ' ORDER BY id DESC')
     res.json(recordset)
@@ -45,12 +45,13 @@ exports.create = async (req, res, next) => {
     const pool = getPool()
     const result = await pool
       .request()
+      .input('userId', sql.Int, req.userId)
       .input('title', sql.NVarChar, value.title)
       .input('description', sql.NVarChar, value.description || null)
       .input('priority', sql.NVarChar, value.priority || 'Low')
       .input('completed', sql.Bit, value.completed ?? false)
       .query(
-        'INSERT INTO Tasks (title, description, priority, completed) OUTPUT INSERTED.* VALUES (@title, @description, @priority, @completed)'
+        'INSERT INTO Tasks (userId, title, description, priority, completed) OUTPUT INSERTED.* VALUES (@userId, @title, @description, @priority, @completed)'
       )
     res.status(201).json(result.recordset[0])
   } catch (err) {
@@ -68,23 +69,25 @@ exports.update = async (req, res, next) => {
     const { recordset } = await pool
       .request()
       .input('id', sql.Int, req.params.id)
-      .query('SELECT * FROM Tasks WHERE id=@id')
+      .input('userId', sql.Int, req.userId)
+      .query('SELECT * FROM Tasks WHERE id=@id AND userId=@userId')
     if (recordset.length === 0) return res.status(404).json({ error: 'Task not found' })
 
     const fields = []
-    const request = pool.request().input('id', sql.Int, req.params.id)
+    const request = pool.request().input('id', sql.Int, req.params.id).input('userId', sql.Int, req.userId)
     if (value.title !== undefined) { request.input('title', sql.NVarChar, value.title); fields.push('title=@title') }
     if (value.description !== undefined) { request.input('description', sql.NVarChar, value.description); fields.push('description=@description') }
     if (value.priority !== undefined) { request.input('priority', sql.NVarChar, value.priority); fields.push('priority=@priority') }
     if (value.completed !== undefined) { request.input('completed', sql.Bit, value.completed); fields.push('completed=@completed') }
     if (fields.length > 0) {
-      await request.query(`UPDATE Tasks SET ${fields.join(', ')} WHERE id=@id`)
+      await request.query(`UPDATE Tasks SET ${fields.join(', ')} WHERE id=@id AND userId=@userId`)
     }
 
     const { recordset: updated } = await pool
       .request()
       .input('id', sql.Int, req.params.id)
-      .query('SELECT * FROM Tasks WHERE id=@id')
+      .input('userId', sql.Int, req.userId)
+      .query('SELECT * FROM Tasks WHERE id=@id AND userId=@userId')
     res.json(updated[0])
   } catch (err) {
     next(err);
@@ -98,8 +101,9 @@ exports.toggle = async (req, res, next) => {
     const result = await pool
       .request()
       .input('id', sql.Int, req.params.id)
+      .input('userId', sql.Int, req.userId)
       .query(
-        'UPDATE Tasks SET completed = CASE WHEN completed = 1 THEN 0 ELSE 1 END OUTPUT INSERTED.* WHERE id=@id'
+        'UPDATE Tasks SET completed = CASE WHEN completed = 1 THEN 0 ELSE 1 END OUTPUT INSERTED.* WHERE id=@id AND userId=@userId'
       )
     if (result.recordset.length === 0) return res.status(404).json({ error: 'Task not found' })
     res.json(result.recordset[0])
@@ -115,7 +119,8 @@ exports.remove = async (req, res, next) => {
     const result = await pool
       .request()
       .input('id', sql.Int, req.params.id)
-      .query('DELETE FROM Tasks WHERE id=@id')
+      .input('userId', sql.Int, req.userId)
+      .query('DELETE FROM Tasks WHERE id=@id AND userId=@userId')
     if (result.rowsAffected[0] === 0) return res.status(404).json({ error: 'Task not found' })
     res.json({ message: 'Task deleted' })
   } catch (err) {

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,8 +1,11 @@
 const express = require('express');
 const router = express.Router();
 const authController = require('../controllers/authController');
+const auth = require('../middleware/auth');
 
 router.post('/register', authController.register);
 router.post('/login', authController.login);
+router.get('/me', auth, authController.profile);
+router.put('/me', auth, authController.updateProfile);
 
 module.exports = router;

--- a/src/routes/tasks.js
+++ b/src/routes/tasks.js
@@ -1,11 +1,12 @@
 const express = require('express');
 const router = express.Router();
 const taskController = require('../controllers/taskController');
+const auth = require('../middleware/auth');
 
-router.get('/', taskController.list);
-router.post('/', taskController.create);
-router.put('/:id', taskController.update);
-router.patch('/:id/toggle', taskController.toggle);
-router.delete('/:id', taskController.remove);
+router.get('/', auth, taskController.list);
+router.post('/', auth, taskController.create);
+router.put('/:id', auth, taskController.update);
+router.patch('/:id/toggle', auth, taskController.toggle);
+router.delete('/:id', auth, taskController.remove);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add AuthProvider with login/register/update logic
- create login, register and profile pages
- secure tasks API with auth middleware
- associate tasks with user IDs in the database
- update header with account icon and dark mode toggle
- send auth token in task operations

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9fc8fc44832181b75fa2592b0000