### PR TITLE
Update auth pages with new design

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { useAuth } from "@/context/auth-provider"
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { AuthLayout } from "@/components/AuthLayout"
 import { Button } from "@/components/ui/button"
 import { motion } from "framer-motion"
 import clsx from "clsx"
@@ -33,64 +33,51 @@ export default function LoginPage() {
   const MotionButton = motion(Button)
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-sky-200 via-white to-emerald-200 dark:from-gray-900 dark:via-gray-950 dark:to-gray-900 p-4">
+    <AuthLayout title="Giriş Yap" description="Görevlerinizi yönetin">
       <motion.form
         onSubmit={handleSubmit}
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        className="w-full max-w-md"
+        className="space-y-4"
       >
-        <Card className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-md shadow-deep">
-          <CardHeader>
-            <h1 className="text-3xl font-bold text-center bg-gradient-to-r from-emerald-500 to-sky-500 bg-clip-text text-transparent">
-              Giriş Yap
-            </h1>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div>
-              <label htmlFor="email" className="block text-sm mb-1">
-                Email
-              </label>
-              <input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                className="w-full rounded-md border border-input bg-background px-4 py-2 focus:ring-2 focus:ring-primary"
-              />
-            </div>
-            <div>
-              <label htmlFor="password" className="block text-sm mb-1">
-                Şifre
-              </label>
-              <input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                className="w-full rounded-md border border-input bg-background px-4 py-2 focus:ring-2 focus:ring-primary"
-              />
-            </div>
-            {error && <p className={clsx("text-sm", error && "text-red-600")}>{error}</p>}
-            <MotionButton
-              type="submit"
-              className="w-full"
-              whileTap={{ scale: 0.95 }}
-            >
-              Giriş Yap
-            </MotionButton>
-            <p className="text-sm text-center">
-              Hesabınız yok mu?{" "}
-              <Link href="/register" className="text-blue-600 hover:underline">
-                Kayıt Ol
-              </Link>
-            </p>
-          </CardContent>
-        </Card>
+        <div>
+          <label htmlFor="email" className="block text-sm mb-1">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="w-full rounded-md border border-input bg-background px-4 py-2 focus:ring-2 focus:ring-primary"
+          />
+        </div>
+        <div>
+          <label htmlFor="password" className="block text-sm mb-1">
+            Şifre
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="w-full rounded-md border border-input bg-background px-4 py-2 focus:ring-2 focus:ring-primary"
+          />
+        </div>
+        {error && <p className={clsx("text-sm", error && "text-red-600")}>{error}</p>}
+        <MotionButton type="submit" className="w-full" whileTap={{ scale: 0.95 }}>
+          Giriş Yap
+        </MotionButton>
+        <p className="text-sm text-center">
+          Hesabınız yok mu?{" "}
+          <Link href="/register" className="text-primary hover:underline">
+            Kayıt Ol
+          </Link>
+        </p>
       </motion.form>
       <Toast />
-    </div>
+    </AuthLayout>
   )
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { useAuth } from "@/context/auth-provider"
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { AuthLayout } from "@/components/AuthLayout"
 import { Button } from "@/components/ui/button"
 import { motion } from "framer-motion"
 import clsx from "clsx"
@@ -39,55 +39,46 @@ export default function ProfilePage() {
   const MotionButton = motion(Button)
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-sky-200 via-white to-emerald-200 dark:from-gray-900 dark:via-gray-950 dark:to-gray-900 p-4">
+    <AuthLayout title="Profil" description="Bilgilerinizi güncelleyin">
       <motion.form
         onSubmit={handleSubmit}
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        className="w-full max-w-md"
+        className="space-y-4"
       >
-        <Card className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-md shadow-deep">
-          <CardHeader>
-            <h1 className="text-3xl font-bold text-center bg-gradient-to-r from-emerald-500 to-sky-500 bg-clip-text text-transparent">
-              Profil
-            </h1>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div>
-              <label htmlFor="email" className="block text-sm mb-1">
-                Email
-              </label>
-              <input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                className="w-full rounded-md border border-input bg-background px-4 py-2 focus:ring-2 focus:ring-primary"
-              />
-            </div>
-            <div>
-              <label htmlFor="password" className="block text-sm mb-1">
-                Yeni Şifre
-              </label>
-              <input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className={clsx(
-                  "w-full rounded-md border border-input bg-background px-4 py-2 focus:ring-2 focus:ring-primary",
-                  password && "ring-1 ring-primary/50",
-                )}
-              />
-            </div>
-            <MotionButton type="submit" className="w-full" whileTap={{ scale: 0.95 }}>
-              Güncelle
-            </MotionButton>
-          </CardContent>
-        </Card>
+        <div>
+          <label htmlFor="email" className="block text-sm mb-1">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="w-full rounded-md border border-input bg-background px-4 py-2 focus:ring-2 focus:ring-primary"
+          />
+        </div>
+        <div>
+          <label htmlFor="password" className="block text-sm mb-1">
+            Yeni Şifre
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className={clsx(
+              "w-full rounded-md border border-input bg-background px-4 py-2 focus:ring-2 focus:ring-primary",
+              password && "ring-1 ring-primary/50"
+            )}
+          />
+        </div>
+        <MotionButton type="submit" className="w-full" whileTap={{ scale: 0.95 }}>
+          Güncelle
+        </MotionButton>
       </motion.form>
       <Toast />
-    </div>
+    </AuthLayout>
   )
 }

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { useAuth } from "@/context/auth-provider"
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { AuthLayout } from "@/components/AuthLayout"
 import { Button } from "@/components/ui/button"
 import { motion } from "framer-motion"
 import clsx from "clsx"
@@ -33,64 +33,51 @@ export default function RegisterPage() {
   const MotionButton = motion(Button)
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-sky-200 via-white to-emerald-200 dark:from-gray-900 dark:via-gray-950 dark:to-gray-900 p-4">
+    <AuthLayout title="Kayıt Ol" description="Hemen başlayın">
       <motion.form
         onSubmit={handleSubmit}
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        className="w-full max-w-md"
+        className="space-y-4"
       >
-        <Card className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-md shadow-deep">
-          <CardHeader>
-            <h1 className="text-3xl font-bold text-center bg-gradient-to-r from-emerald-500 to-sky-500 bg-clip-text text-transparent">
-              Kayıt Ol
-            </h1>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div>
-              <label htmlFor="email" className="block text-sm mb-1">
-                Email
-              </label>
-              <input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                className="w-full rounded-md border border-input bg-background px-4 py-2 focus:ring-2 focus:ring-primary"
-              />
-            </div>
-            <div>
-              <label htmlFor="password" className="block text-sm mb-1">
-                Şifre
-              </label>
-              <input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                className="w-full rounded-md border border-input bg-background px-4 py-2 focus:ring-2 focus:ring-primary"
-              />
-            </div>
-            {error && <p className={clsx("text-sm", error && "text-red-600")}>{error}</p>}
-            <MotionButton
-              type="submit"
-              className="w-full"
-              whileTap={{ scale: 0.95 }}
-            >
-              Kayıt Ol
-            </MotionButton>
-            <p className="text-sm text-center">
-              Zaten hesabınız var mı?{" "}
-              <Link href="/login" className="text-blue-600 hover:underline">
-                Giriş Yap
-              </Link>
-            </p>
-          </CardContent>
-        </Card>
+        <div>
+          <label htmlFor="email" className="block text-sm mb-1">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="w-full rounded-md border border-input bg-background px-4 py-2 focus:ring-2 focus:ring-primary"
+          />
+        </div>
+        <div>
+          <label htmlFor="password" className="block text-sm mb-1">
+            Şifre
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="w-full rounded-md border border-input bg-background px-4 py-2 focus:ring-2 focus:ring-primary"
+          />
+        </div>
+        {error && <p className={clsx("text-sm", error && "text-red-600")}>{error}</p>}
+        <MotionButton type="submit" className="w-full" whileTap={{ scale: 0.95 }}>
+          Kayıt Ol
+        </MotionButton>
+        <p className="text-sm text-center">
+          Zaten hesabınız var mı?{" "}
+          <Link href="/login" className="text-primary hover:underline">
+            Giriş Yap
+          </Link>
+        </p>
       </motion.form>
       <Toast />
-    </div>
+    </AuthLayout>
   )
 }

--- a/components/AuthLayout.tsx
+++ b/components/AuthLayout.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { ReactNode } from "react"
+import { Card } from "@/components/ui/card"
+
+interface AuthLayoutProps {
+  title: string
+  description?: string
+  children: ReactNode
+}
+
+export function AuthLayout({ title, description, children }: AuthLayoutProps) {
+  return (
+    <div className="flex min-h-screen items-center justify-center overflow-x-hidden py-10 bg-background">
+      <div className="relative flex items-center justify-center px-4 sm:px-6 lg:px-8">
+        <div className="absolute pointer-events-none">
+          <svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="100" cy="100" r="98" stroke="var(--color-primary)" strokeDasharray="8 8" strokeOpacity="0.3" />
+          </svg>
+        </div>
+        <Card className="relative z-10 w-full space-y-6 rounded-xl p-6 shadow-md sm:min-w-md lg:p-8">
+          <div className="flex items-center gap-3">
+            <img src="https://cdn.flyonui.com/fy-assets//logo/logo.png" className="size-8" alt="brand-logo" />
+            <h2 className="text-xl font-bold">TodoManager</h2>
+          </div>
+          <div>
+            <h3 className="mb-1.5 text-2xl font-semibold">{title}</h3>
+            {description && <p className="text-muted-foreground">{description}</p>}
+          </div>
+          {children}
+        </Card>
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add `AuthLayout` component with shared styling for auth pages
- restyle login, register and profile pages to use new layout

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden due to no network access)*

------
https://chatgpt.com/codex/tasks/task_e_686bb02c90548321be6f28071158567a