### PR TITLE
Fix stale token in task hooks

### DIFF
--- a/hooks/use-tasks.ts
+++ b/hooks/use-tasks.ts
@@ -47,7 +47,7 @@ export function useTaskOperations() {
         })
       }
     },
-    [dispatch],
+    [dispatch, token],
   )
 
   // Update an existing task
@@ -89,7 +89,7 @@ export function useTaskOperations() {
         })
       }
     },
-    [dispatch],
+    [dispatch, token],
   )
 
   // Delete a task with undo functionality
@@ -127,7 +127,7 @@ export function useTaskOperations() {
         })
       }
     },
-    [state.tasks, dispatch],
+    [state.tasks, dispatch, token],
   )
 
   // Toggle task completion status
@@ -151,7 +151,7 @@ export function useTaskOperations() {
         })
       }
     },
-    [dispatch],
+    [dispatch, token],
   )
 
   return {


### PR DESCRIPTION
## Summary
- refresh task operation callbacks when auth token updates

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d16015610832198443a13a2d26c75